### PR TITLE
Fix up console methods in IE

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -2,6 +2,15 @@
 
 module.exports = log;
 
+// Fix up console methods in IE
+if (Function.prototype.bind &&
+  window.console &&
+  typeof console.log === 'object') {
+  ['log', 'warn'].forEach(function(method) {
+      console[method] = this.bind(console[method], console);
+    }, Function.prototype.call);
+}
+
 function log()
 {
   return console.log.apply(console, arguments);


### PR DESCRIPTION
This fixes `console` methods not working in IE9 when Developer Tools aren't open. Via: http://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9/5539378#5539378
