### PR TITLE
No-op for IE console methods

### DIFF
--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -2,6 +2,15 @@
 
 module.exports = log;
 
+// Fix up console methods in IE
+if (Function.prototype.bind &&
+  window.console &&
+  typeof console.log === 'object') {
+  ['log', 'warn'].forEach(function(method) {
+      console[method] = this.bind(console[method], console);
+    }, Function.prototype.call);
+}
+
 function log()
 {
   return console.log.apply(console, arguments);

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -2,22 +2,23 @@
 
 module.exports = log;
 
-// Fix up console methods in IE
+var SUPPORTED = true;
+
 if (Function.prototype.bind &&
   window.console &&
   typeof console.log === 'object') {
-  ['log', 'warn'].forEach(function(method) {
-      console[method] = this.bind(console[method], console);
-    }, Function.prototype.call);
+  SUPPORTED = false;
 }
 
 function log()
 {
-  return console.log.apply(console, arguments);
+  if (SUPPORTED)
+    return console.log.apply(console, arguments);
 }
 
 log.warn = function()
 {
-  return console.warn.apply(console, arguments);
+  if (SUPPORTED)
+    return console.warn.apply(console, arguments);
 };
 


### PR DESCRIPTION
Alternative fix to messing with the global `console` object.
